### PR TITLE
Feat: Use aiortc.contrib.media to stream

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,3 @@ aiohttp==3.10.10
 aiohttp_jinja2==1.6
 aiopg==1.3.3
 aiortc==1.9.0
-opencv-python==4.10.0.84
-pyav==13.1.0
-windows-capture==1.3.6; sys_platform == "win32"


### PR DESCRIPTION
This PR removes obsolete features and dependencies from the project in the realization that many such features were already available through `aiortc.contrib.media` module.

The latency observed in screen sharing context is extremely low (<1 seconds) and seamless.

Linux users of this organization are requested to research their ffmpeg supported screen recording capabilities with either `x11grab` or any other ffmpeg-supported formats so that this server remains cross-platform.

Windows Capture has been removed in favor of `gdigrab`.