### PR TITLE
Proper Postgres Pool handling

### DIFF
--- a/aether_server/__main__.py
+++ b/aether_server/__main__.py
@@ -10,7 +10,7 @@ from aether_server.routes import generic_routes
 def create_app(_) -> web.Application:
     project_root = pathlib.Path(__file__).parent
     app = web.Application()
-    set_context_for(app, use_database=False)
+    set_context_for(app)
 
     app.router.add_static("/static/", path=project_root / "static", name="static")
     app.add_routes(generic_routes)

--- a/aether_server/__main__.py
+++ b/aether_server/__main__.py
@@ -1,55 +1,23 @@
-import asyncio
 import pathlib
 
-import aiohttp
 import aiohttp.web as web
 import aiohttp_jinja2
-import jinja2
 
-from aether_server.db import setup_database
+from aether_server.core import set_context_for
 from aether_server.routes import generic_routes
-from aether_server.routes.utils import HTTP_CLIENT_APPKEY, RTC_APPKEY, RTCPeerManager
-
-try:
-    import dotenv
-
-    dotenv.load_dotenv()
-except ImportError:
-    ...
-
-try:
-    import aiohttp_debugtoolbar
-except ImportError:
-    aiohttp_debugtoolbar = None
-
-
-async def peer_manager_clearing_ctx(app: web.Application):
-    app[RTC_APPKEY] = RTCPeerManager()
-    yield
-    await app[RTC_APPKEY].close()
-
-
-async def http_client_clearing_ctx(app: web.Application):
-    app[HTTP_CLIENT_APPKEY] = aiohttp.ClientSession()
-    yield
-    await app[HTTP_CLIENT_APPKEY].close()
 
 
 def create_app(_) -> web.Application:
     project_root = pathlib.Path(__file__).parent
-    asyncio.run(setup_database())
     app = web.Application()
+    set_context_for(app, use_database=False)
 
     app.router.add_static("/static/", path=project_root / "static", name="static")
     app.add_routes(generic_routes)
-    app.cleanup_ctx.extend((peer_manager_clearing_ctx, http_client_clearing_ctx))
 
     aiohttp_jinja2.setup(
-        app, loader=jinja2.FileSystemLoader(project_root / "templates")
+        app, loader=aiohttp_jinja2.jinja2.FileSystemLoader(project_root / "templates")
     )
-
-    if aiohttp_debugtoolbar is not None:
-        aiohttp_debugtoolbar.setup(app, intercept_redirects=False)
 
     return app
 

--- a/aether_server/core.py
+++ b/aether_server/core.py
@@ -89,9 +89,7 @@ class AetherContext:
             await self.__database_pool.wait_closed()
 
 
-def set_context_for(
-    app: web.Application, use_database: bool = False, development_mode=True
-):
+def set_context_for(app: web.Application, development_mode=True):
     if development_mode:
         with suppress(ImportError):
             import dotenv
@@ -102,6 +100,8 @@ def set_context_for(
             import aiohttp_debugtoolbar
 
             aiohttp_debugtoolbar.setup(app, intercept_redirects=False)
+
+    use_database = os.getenv("USE_DATABASE", "0") == "1"
 
     if use_database:
         set_windows_loop_policy()

--- a/aether_server/core.py
+++ b/aether_server/core.py
@@ -1,0 +1,111 @@
+import asyncio
+import os
+import sys
+from contextlib import suppress
+
+import aiohttp
+import aiohttp.web as web
+import aiopg
+
+from .db import POOL_APPKEY, schema_path, try_fetch_login_params_from_env
+from .routes.utils import HTTP_CLIENT_APPKEY, RTC_APPKEY, RTCPeerManager
+
+
+def set_windows_loop_policy():
+    if sys.platform == "win32":
+        print(
+            "Selector policy is in use for aiopg on Windows.\n"
+            "This policy is known to mishandle signals.\n"
+            f"Please kill the process with PID {os.getpid()} if required.",
+            file=sys.__stderr__,
+        )
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
+
+class AetherContext:
+    """
+    Project-only context creation for
+    `aiohttp.web.Application`.
+    """
+
+    def __init__(self, app: web.Application, use_database: bool = False):
+        self.app = app
+        self.use_database = use_database
+
+        self.__rtc_peer_manager = None
+        self.__http_client = None
+
+        self.__database_pool = None
+
+        self.app.on_shutdown.append(lambda _: self.close())
+
+    async def __setup_rtc_peer_manager(self):
+        self.__rtc_peer_manager = RTCPeerManager()
+        self.app[RTC_APPKEY] = self.__rtc_peer_manager
+
+    async def __setup_http_client(self):
+        self.__http_client = aiohttp.ClientSession(
+            headers={"User-Agent": "Aether/1.0 (unreleased)"}
+        )
+        self.app[HTTP_CLIENT_APPKEY] = self.__http_client
+
+    async def __setup_database(self):
+        self.__database_pool = await aiopg.create_pool(
+            try_fetch_login_params_from_env()
+        )
+        async with self.__database_pool.acquire() as conn:
+            async with conn.cursor() as cur:
+                await cur.execute(schema_path.read_text(encoding="utf-8"))
+
+        self.app[POOL_APPKEY] = self.__database_pool
+
+    def __call__(self, *args, **kwds):
+        return self
+
+    async def create(self):
+        setup_coros = [
+            self.__setup_rtc_peer_manager,
+            self.__setup_http_client,
+        ]
+
+        if self.use_database:
+            setup_coros.append(self.__setup_database)
+
+        for setup_coro in setup_coros:
+            await setup_coro()
+
+        yield
+        await self.close()
+
+    async def close(self):
+        if self.__rtc_peer_manager is not None:
+            await self.__rtc_peer_manager.close()
+
+        if self.__http_client is not None:
+            await self.__http_client.close()
+
+        if self.__database_pool is not None:
+            self.__database_pool.close()
+            await self.__database_pool.wait_closed()
+
+
+def set_context_for(
+    app: web.Application, use_database: bool = False, development_mode=True
+):
+    if development_mode:
+        with suppress(ImportError):
+            import dotenv
+
+            dotenv.load_dotenv()
+
+        with suppress(ImportError):
+            import aiohttp_debugtoolbar
+
+            aiohttp_debugtoolbar.setup(app, intercept_redirects=False)
+
+    if use_database:
+        set_windows_loop_policy()
+
+    app.cleanup_ctx.append(
+        lambda app: AetherContext(app, use_database=use_database).create()
+    )

--- a/aether_server/db/__init__.py
+++ b/aether_server/db/__init__.py
@@ -1,6 +1,3 @@
-from .database import ExecuteQuery, setup_database
+from .database import POOL_APPKEY, schema_path, try_fetch_login_params_from_env
 
-__all__ = [
-    "setup_database",
-    "ExecuteQuery",
-]
+__all__ = ["try_fetch_login_params_from_env", "schema_path", "POOL_APPKEY"]

--- a/aether_server/db/schema.sql
+++ b/aether_server/db/schema.sql
@@ -24,29 +24,9 @@ CREATE TABLE IF NOT EXISTS transactions (
     total_cost INT DEFAULT 0,
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 );
-CREATE OR REPLACE FUNCTION mark_transactions_deleted() 
-RETURNS TRIGGER AS $$
-BEGIN
-    UPDATE transactions
 
-    SET customer_id = NULL
-    WHERE customer_id = OLD.id;
-    
-    UPDATE transactions
-    SET landlord_id = NULL
-    WHERE landlord_id = OLD.id;
 
-    RETURN NULL;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE TRIGGER IF NOT EXISTS user_deletion_trigger 
-AFTER DELETE ON users
-FOR EACH ROW
-EXECUTE FUNCTION mark_transactions_deleted();
-
-DROP FUNCTION IF EXISTS calculate_total_cost;
-DROP TRIGGER IF EXISTS update_total_cost ON transactions;
+DROP FUNCTION IF EXISTS calculate_total_cost CASCADE;
 
 CREATE OR REPLACE FUNCTION calculate_total_cost() 
 RETURNS TRIGGER AS $$

--- a/aether_server/routes/utils/__init__.py
+++ b/aether_server/routes/utils/__init__.py
@@ -6,4 +6,4 @@ from .rtc import RTCPeerManager
 RTC_APPKEY = web.AppKey("rtc_peer_manager", RTCPeerManager)
 HTTP_CLIENT_APPKEY = web.AppKey("http_client", aiohttp.ClientSession)
 
-__all__ = ["RTCPeerManager", "RTC_APPKEY"]
+__all__ = ["RTCPeerManager", "RTC_APPKEY", "HTTP_CLIENT_APPKEY"]

--- a/aether_server/routes/utils/rtc.py
+++ b/aether_server/routes/utils/rtc.py
@@ -150,7 +150,7 @@ class RTCPeerManager:
         peer.addTrack(self.__screen_relay.subscribe(self.__screen_track))
 
     async def close(self):
-        for peer in self.peers:
+        for peer in self.peers.copy():
             await peer.close()
 
         self.reset_screen_source()

--- a/aether_server/static/js/main.js
+++ b/aether_server/static/js/main.js
@@ -55,6 +55,7 @@ function openConnection() {
             videoPlayer.play();
         }
 
+        startButton.disabled = true;
         closeButton.disabled = false;
     });
 
@@ -114,6 +115,7 @@ function openConnection() {
         videoPlayer.srcObject = null;
         closeButton.removeEventListener("click", closeHandler)
         closeButton.disabled = true;
+        startButton.disabled = false;
     };
 
     closeButton.addEventListener("click", closeHandler)

--- a/compose.yaml
+++ b/compose.yaml
@@ -15,9 +15,9 @@ services:
     image: postgres:14-alpine
     restart: always
     environment:
-      - POSTGRES_DB= aether
-      - POSTGRES_USER= root
-      - POSTGRES_PASSWORD= secret
+      - POSTGRES_DB=aether
+      - POSTGRES_USER=root
+      - POSTGRES_PASSWORD=secret
     ports:
       - "5432:5432"
     networks:


### PR DESCRIPTION
Yet to test `aiopg.Pool` on Linux.

This PR implements separate and proper `web.Application` context creations.

## Windows support

```py
def set_windows_loop_policy():
    if sys.platform == "win32":
        print(
            "Selector policy is in use for aiopg on Windows.\n"
            "This policy is known to mishandle signals.\n"
            f"Please kill the process with PID {os.getpid()} if required.",
            file=sys.__stderr__,
        )
        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
```

The above code allows for proper execution of `aiopg` on Windows.

## Testing

To test your local Postgres databases, use the following environment variables:

```env
USE_DATABASE=1
DB_HOST=...
DB_NAME=...
DB_PASSWORD=...
DB_PORT=...
DB_USER=...
```

This type of environment configuration is subject to change later.
